### PR TITLE
chore: migrate to current Anthropic model ID

### DIFF
--- a/src-tauri/src/services/llm_generator.rs
+++ b/src-tauri/src/services/llm_generator.rs
@@ -40,7 +40,7 @@ pub async fn generate_test_with_llm(
         .build()
         .map_err(AppError::Http)?;
     let request = ClaudeRequest {
-        model: "claude-sonnet-4-20250514".to_string(),
+        model: "claude-sonnet-4-6".to_string(),
         max_tokens: 2048,
         messages: vec![Message {
             role: "user".to_string(),


### PR DESCRIPTION
claude-sonnet-4-20250514 -> claude-sonnet-4-6 (1 ref)

The dated Sonnet 4 alias retires 2026-06-15. After that date,
requests using the old ID return a hard error with no fallback.

Verified: cargo check passes for src-tauri.

Refs: https://platform.claude.com/docs/en/about-claude/model-deprecations

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
