### PR TITLE
test(tauri): add desktop workflow smoke

### DIFF
--- a/.codex/actions/test.sh
+++ b/.codex/actions/test.sh
@@ -8,12 +8,4 @@ if [ -f "$SCRIPT_DIR/_artifact_env.sh" ]; then
   source "$SCRIPT_DIR/_artifact_env.sh"
 fi
 
-echo "NOT_RUN: No test script is documented in README.md or package.json for this repo."
-echo "Add a canonical test command before treating production-ready quality gates as passing."
-
-if [ "${CODEX_ALLOW_NOT_RUN_GATES:-0}" = "1" ]; then
-  echo "Bypass enabled via CODEX_ALLOW_NOT_RUN_GATES=1; continuing with documented risk."
-  exit 0
-fi
-
-exit 3
+pnpm verify

--- a/.codex/commands.md
+++ b/.codex/commands.md
@@ -1,9 +1,10 @@
 # SpecCompanion .codex command map
 
-| Action | Command | Source |
-| --- | --- | --- |
-| setup deps | `pnpm install` | `README.md` |
-| lint fallback | `pnpm run build` | `package.json` (no dedicated lint script) |
-| test | _none configured (blocks by default as NOT_RUN; bypass only with `CODEX_ALLOW_NOT_RUN_GATES=1` + explicit risk acceptance)_ | `README.md`, `package.json` |
-| build | `pnpm run build` | `README.md`, `package.json` |
-| lean dev | `pnpm run dev:lean` | `README.md`, `package.json` |
+| Action           | Command               | Source                                 |
+| ---------------- | --------------------- | -------------------------------------- |
+| setup deps       | `pnpm install`        | `README.md`                            |
+| lint/static gate | `pnpm ui:gate:static` | `package.json`                         |
+| test             | `pnpm verify`         | `package.json`                         |
+| workflow smoke   | `pnpm workflow:smoke` | `package.json`, `src-tauri/src/lib.rs` |
+| build            | `pnpm run build`      | `README.md`, `package.json`            |
+| lean dev         | `pnpm run dev:lean`   | `README.md`, `package.json`            |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ui:test:visual": "playwright test tests/ui --grep @visual",
     "ui:test:a11y": "playwright test tests/ui --grep @a11y",
     "ui:test:lighthouse": "pnpm build && lhci autorun --config=.lighthouserc.json",
+    "workflow:smoke": "cargo test --manifest-path src-tauri/Cargo.toml desktop_workflow_smoke_generates_executes_and_reports",
     "ui:gate:regression": "pnpm ui:test:visual && pnpm ui:test:a11y",
     "ui:gate": "pnpm ui:gate:static && pnpm ui:gate:regression && pnpm ui:test:lighthouse",
     "ui:test:visual:update": "playwright test tests/ui --grep @visual --update-snapshots",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,8 +19,7 @@ pub fn run() {
                 .path()
                 .app_data_dir()
                 .expect("failed to get app data dir");
-            let database = Database::new(&app_data_dir)
-                .expect("failed to initialize database");
+            let database = Database::new(&app_data_dir).expect("failed to initialize database");
             app.manage(database);
             Ok(())
         })
@@ -60,4 +59,117 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod desktop_workflow_tests {
+    use super::*;
+    use crate::db::queries;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::test::{GeneratedTest, TestResult};
+    use crate::services::{alignment, spec_parser, template_generator, test_runner};
+    use chrono::Utc;
+    use std::fs;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    #[test]
+    fn desktop_workflow_smoke_generates_executes_and_reports() {
+        let fixture = WorkflowFixture::new("desktop_workflow_smoke");
+        let codebase_path = fixture.root.join("codebase");
+        fs::create_dir_all(&codebase_path).expect("create codebase fixture");
+        fs::write(
+            codebase_path.join("calculator.py"),
+            "def add(left, right):\n    return left + right\n",
+        )
+        .expect("write code fixture");
+
+        let db = Database::new(&fixture.root.join("app-data")).expect("initialize database");
+        let conn = db.conn.lock().expect("lock database");
+
+        let project = queries::create_project(
+            &conn,
+            &CreateProjectRequest {
+                name: "Workflow Smoke".to_string(),
+                codebase_path: codebase_path.to_string_lossy().to_string(),
+            },
+        )
+        .expect("create project");
+
+        let spec = queries::create_spec(
+            &conn,
+            &project.id,
+            "workflow-smoke.md",
+            "# Workflow Smoke\n\n## Requirements\n\n- The system shall add two numbers\n",
+        )
+        .expect("create spec");
+        let requirements = spec_parser::parse_spec(&spec.id, &spec.content);
+        assert_eq!(requirements.len(), 1);
+        queries::insert_requirements(&conn, &requirements).expect("insert requirements");
+        queries::update_spec_parsed_at(&conn, &spec.id).expect("mark spec parsed");
+
+        let generated = GeneratedTest {
+            id: Uuid::new_v4().to_string(),
+            requirement_id: requirements[0].id.clone(),
+            framework: "pytest".to_string(),
+            code: template_generator::generate_pytest_test(&requirements[0], &[]),
+            generation_mode: "template".to_string(),
+            file_path: None,
+            created_at: Utc::now().to_rfc3339(),
+        };
+        queries::insert_generated_test(&conn, &generated).expect("store generated test");
+
+        let test_path = fixture.root.join("test_workflow_smoke.py");
+        fs::write(&test_path, &generated.code).expect("write generated pytest file");
+        queries::update_generated_test_path(&conn, &generated.id, &test_path.to_string_lossy())
+            .expect("store generated test path");
+
+        let execution = test_runner::run_pytest_test(
+            &test_path.to_string_lossy(),
+            &codebase_path.to_string_lossy(),
+        )
+        .expect("run generated pytest");
+        assert_eq!(execution.status, "passed", "stderr: {}", execution.stderr);
+
+        let result = TestResult {
+            id: Uuid::new_v4().to_string(),
+            generated_test_id: generated.id.clone(),
+            status: execution.status,
+            execution_time_ms: execution.execution_time_ms,
+            stdout: execution.stdout,
+            stderr: execution.stderr,
+            executed_at: Utc::now().to_rfc3339(),
+        };
+        queries::insert_test_result(&conn, &result).expect("store test result");
+
+        let report =
+            alignment::generate_report(&conn, &project.id).expect("generate alignment report");
+        assert_eq!(report.report.total_requirements, 1);
+        assert_eq!(report.report.covered_requirements, 1);
+        assert_eq!(report.report.coverage_percent, 100.0);
+        assert!(report.mismatches.is_empty());
+    }
+
+    struct WorkflowFixture {
+        root: PathBuf,
+    }
+
+    impl WorkflowFixture {
+        fn new(name: &str) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "spec-companion-{}-{}-{}",
+                name,
+                std::process::id(),
+                Uuid::new_v4()
+            ));
+            fs::create_dir_all(&root).expect("create workflow fixture");
+            Self { root }
+        }
+    }
+
+    impl Drop for WorkflowFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
 }


### PR DESCRIPTION
## What
- Adds a backend smoke test for the desktop workflow: project creation, spec parsing, test generation, test execution, and alignment reporting.
- Adds a `pnpm workflow:smoke` script for repeatable targeted verification.
- Updates the Codex command map and test action to use the real project verifier.

## Why
- The project needed a repeatable proof that the core desktop workflow works below the UI layer before expanding product work.

## How
- Uses a temporary Python fixture and the existing database/query/service layers to exercise the workflow end to end.

## Testing
- `pnpm workflow:smoke` passed.
- `bash .codex/actions/test.sh` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml` passed.

## Performance Impact
- None expected; this adds test coverage and scripts only.

## Risk / Notes
- Existing Rust test warning remains: an unused import in `src/services/alignment.rs`.
- Direct git push is blocked in this environment, so the branch was published through the GitHub API.