### PR TITLE
chore: track pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
Already configured with `allowBuilds.esbuild: true` to whitelist the esbuild build script for pnpm v9+. Belongs in version control so everyone running `pnpm install` gets the same build-script policy.