### PR TITLE
ci: skip lockfile rationale for Dependabot

### DIFF
--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   enforce:
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.event.pull_request.head.ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What
- Skips the lockfile-rationale enforcement job for Dependabot-authored PRs and `dependabot/*` branches.
- Keeps the rationale requirement active for human-authored lockfile changes.

## Why
- Current Dependabot npm security PRs are otherwise green but blocked because generated Dependabot bodies do not include the repo-specific lockfile rationale heading.
- Unblocking those PRs lets the critical/high dependency updates proceed through normal CI.

## How
- Adds the same Dependabot actor/head-ref guard already used by git-hygiene.

## Testing
- `git diff --check`
- `pnpm git:guard:all`

## Performance impact
- None expected; workflow policy only.

## Risks
- Dependabot lockfile diffs rely on package-manager metadata and CI checks rather than human rationale text. Human lockfile PRs remain gated.