### PR TITLE
fix(ui): support browser preview QA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@
 ## Communication Contract (Global)
 
 - Follow `/Users/d/.codex/policies/communication/BigPictureReportingV1.md` for all user-facing updates.
-- Use exact section labels from `BigPictureReportingV1.md` for default status/progress updates.
-- Keep default updates beginner-friendly, big-picture, and low-noise.
-- Keep technical details in internal artifacts unless explicitly requested by the user.
+- Use exact section labels from `BigPictureReportingV1.md` for formal delivery, blocker, waiting, risk, decision, or explicit status/report requests.
+- Keep ordinary in-flight updates conversational, warm, PM-readable, operator-grade, and low-noise.
+- Keep technical details in internal artifacts unless explicitly requested by the user or required by failure, risk, or verification.
 - Honor toggles literally: `simple mode`, `show receipts`, `tech mode`, `debug mode`.
 <!-- comm-contract:end -->
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -541,9 +541,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
@@ -698,6 +698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,12 +782,6 @@ dependencies = [
  "redox_users",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -1779,7 +1784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2074,12 +2079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2107,15 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2305,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2318,10 +2326,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2355,12 +2363,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2422,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -2440,6 +2442,27 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2465,6 +2488,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2524,8 +2579,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2918,6 +2992,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4173,35 +4260,35 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.5"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
- "dispatch",
+ "dbus",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -4230,9 +4317,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4311,7 +4398,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4468,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -4908,9 +4995,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -4922,10 +5009,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5844,24 +5931,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever 0.29.1",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
  "objc2",

--- a/src-tauri/src/services/alignment.rs
+++ b/src-tauri/src/services/alignment.rs
@@ -124,8 +124,6 @@ pub fn generate_report(conn: &Connection, project_id: &str) -> Result<AlignmentR
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     // Helper function to test coverage calculation
     fn calculate_coverage_percent(total: i64, covered: i64) -> f64 {
         if total > 0 {

--- a/src/components/project/CreateProjectDialog.tsx
+++ b/src/components/project/CreateProjectDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { isTauriRuntime } from "../../lib/api";
 import { useCreateProject } from "../../hooks/useProjects";
 
 interface Props {
@@ -10,8 +11,10 @@ export function CreateProjectDialog({ onClose }: Props) {
   const [name, setName] = useState("");
   const [codebasePath, setCodebasePath] = useState("");
   const createProject = useCreateProject();
+  const canBrowse = isTauriRuntime();
 
   const handleSelectFolder = async () => {
+    if (!canBrowse) return;
     const selected = await open({ directory: true, multiple: false });
     if (selected && typeof selected === "string") {
       setCodebasePath(selected);
@@ -32,45 +35,52 @@ export function CreateProjectDialog({ onClose }: Props) {
     if (!name.trim() || !codebasePath.trim()) return;
     createProject.mutate(
       { name: name.trim(), codebase_path: codebasePath.trim() },
-      { onSuccess: onClose }
+      { onSuccess: onClose },
     );
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => !createProject.isPending && onClose()}>
-      <div className="bg-surface-alt border border-border rounded-xl p-6 w-full max-w-md" onClick={(e) => e.stopPropagation()}>
-        <h3 className="text-lg font-semibold mb-4">New Project</h3>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => !createProject.isPending && onClose()}
+    >
+      <div
+        className="bg-surface-alt border-border w-full max-w-md rounded-xl border p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-4 text-lg font-semibold">New Project</h3>
         {createProject.isError && (
-          <div className="rounded-lg border border-danger/30 bg-danger/5 p-3 text-sm text-danger mb-4">
+          <div className="border-danger/30 bg-danger/5 text-danger mb-4 rounded-lg border p-3 text-sm">
             {String(createProject.error)}
           </div>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm text-text-muted mb-1">Project Name</label>
+            <label className="text-text-muted mb-1 block text-sm">Project Name</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="My Project"
-              className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary"
+              className="bg-surface border-border text-text focus:border-primary w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
               autoFocus
             />
           </div>
           <div>
-            <label className="block text-sm text-text-muted mb-1">Codebase Path</label>
+            <label className="text-text-muted mb-1 block text-sm">Codebase Path</label>
             <div className="flex gap-2">
               <input
                 type="text"
                 value={codebasePath}
                 onChange={(e) => setCodebasePath(e.target.value)}
                 placeholder="/path/to/project"
-                className="flex-1 bg-surface border border-border rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary"
+                className="bg-surface border-border text-text focus:border-primary flex-1 rounded-lg border px-3 py-2 text-sm focus:outline-none"
               />
               <button
                 type="button"
                 onClick={handleSelectFolder}
-                className="px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text-muted hover:bg-surface-hover transition-colors"
+                disabled={!canBrowse}
+                className="bg-surface border-border text-text-muted hover:bg-surface-hover rounded-lg border px-3 py-2 text-sm transition-colors"
               >
                 Browse
               </button>
@@ -80,14 +90,14 @@ export function CreateProjectDialog({ onClose }: Props) {
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm text-text-muted hover:text-text transition-colors"
+              className="text-text-muted hover:text-text px-4 py-2 text-sm transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={!name.trim() || !codebasePath.trim() || createProject.isPending}
-              className="px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm rounded-lg transition-colors disabled:opacity-50"
+              className="bg-primary hover:bg-primary-dark rounded-lg px-4 py-2 text-sm text-white transition-colors disabled:opacity-50"
             >
               {createProject.isPending ? "Creating..." : "Create"}
             </button>

--- a/src/components/report/AlignmentChart.tsx
+++ b/src/components/report/AlignmentChart.tsx
@@ -23,12 +23,12 @@ export function AlignmentChart({ mismatches, totalRequirements, coveredRequireme
   ].filter((d) => d.value > 0);
 
   if (totalRequirements === 0) {
-    return <p className="text-sm text-text-muted">No requirements to analyze.</p>;
+    return <p className="text-text-muted text-sm">No requirements to analyze.</p>;
   }
 
   return (
-    <div className="h-48">
-      <ResponsiveContainer width="100%" height="100%">
+    <div className="h-48 min-w-0">
+      <ResponsiveContainer width="100%" height={192} minWidth={240}>
         <BarChart data={data} layout="vertical" margin={{ left: 60 }}>
           <XAxis type="number" tick={{ fill: "#9393a8", fontSize: 12 }} />
           <YAxis

--- a/src/components/report/CoverageGauge.tsx
+++ b/src/components/report/CoverageGauge.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Cell } from "recharts";
 
 interface Props {
   coveragePercent: number;
@@ -16,25 +16,23 @@ export function CoverageGauge({ coveragePercent, total, covered }: Props) {
 
   return (
     <div className="flex items-center gap-4">
-      <div className="w-24 h-24 relative">
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={data}
-              cx="50%"
-              cy="50%"
-              innerRadius={28}
-              outerRadius={40}
-              startAngle={90}
-              endAngle={-270}
-              dataKey="value"
-              stroke="none"
-            >
-              <Cell fill={color} />
-              <Cell fill="#333348" />
-            </Pie>
-          </PieChart>
-        </ResponsiveContainer>
+      <div className="relative h-24 w-24">
+        <PieChart width={96} height={96}>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={28}
+            outerRadius={40}
+            startAngle={90}
+            endAngle={-270}
+            dataKey="value"
+            stroke="none"
+          >
+            <Cell fill={color} />
+            <Cell fill="#333348" />
+          </Pie>
+        </PieChart>
         <div className="absolute inset-0 flex items-center justify-center">
           <span className="text-lg font-bold" style={{ color }}>
             {coveragePercent.toFixed(0)}%
@@ -42,10 +40,10 @@ export function CoverageGauge({ coveragePercent, total, covered }: Props) {
         </div>
       </div>
       <div>
-        <p className="text-sm text-text">{covered}/{total} requirements covered</p>
-        <p className="text-xs text-text-muted mt-0.5">
-          {total - covered} uncovered
+        <p className="text-text text-sm">
+          {covered}/{total} requirements covered
         </p>
+        <p className="text-text-muted mt-0.5 text-xs">{total - covered} uncovered</p>
       </div>
     </div>
   );

--- a/src/components/spec/SpecUploader.tsx
+++ b/src/components/spec/SpecUploader.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { readFileContent } from "../../lib/api";
+import { isTauriRuntime, readFileContent } from "../../lib/api";
 import { useUploadSpec } from "../../hooks/useSpecs";
 
 interface Props {
@@ -8,6 +9,20 @@ interface Props {
 
 export function SpecUploader({ projectId }: Props) {
   const uploadSpec = useUploadSpec(projectId);
+  const [browserFilename, setBrowserFilename] = useState("qa-spec.md");
+  const [browserContent, setBrowserContent] = useState(`# Checkout Flow Spec
+
+## Requirements
+
+- The system shall let a user create a project from a local codebase path
+- The system shall parse uploaded markdown specifications into requirements
+- As a user, I want generated tests for selected requirements
+
+## Non-Functional Requirements
+
+- The system shall keep the dashboard responsive during preview QA
+`);
+  const canUseNativeDialog = isTauriRuntime();
 
   const handleUpload = async () => {
     try {
@@ -25,15 +40,51 @@ export function SpecUploader({ projectId }: Props) {
     }
   };
 
+  const handleBrowserUpload = () => {
+    if (!browserFilename.trim() || !browserContent.trim()) return;
+
+    uploadSpec.mutate({
+      filename: browserFilename.trim(),
+      content: browserContent,
+    });
+  };
+
+  if (!canUseNativeDialog) {
+    return (
+      <div className="flex flex-col gap-2 sm:w-96">
+        {uploadSpec.isError && <span className="text-danger text-xs">Upload failed</span>}
+        <input
+          type="text"
+          value={browserFilename}
+          onChange={(event) => setBrowserFilename(event.target.value)}
+          className="bg-surface border-border text-text focus:border-primary w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
+          aria-label="Spec filename"
+        />
+        <textarea
+          value={browserContent}
+          onChange={(event) => setBrowserContent(event.target.value)}
+          rows={5}
+          className="bg-surface border-border text-text focus:border-primary w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
+          aria-label="Spec content"
+        />
+        <button
+          onClick={handleBrowserUpload}
+          disabled={!browserFilename.trim() || !browserContent.trim() || uploadSpec.isPending}
+          className="bg-primary hover:bg-primary-dark self-end rounded-lg px-4 py-2 text-sm text-white transition-colors disabled:opacity-50"
+        >
+          {uploadSpec.isPending ? "Uploading..." : "Upload Spec"}
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-2">
-      {uploadSpec.isError && (
-        <span className="text-xs text-danger">Upload failed</span>
-      )}
+      {uploadSpec.isError && <span className="text-danger text-xs">Upload failed</span>}
       <button
         onClick={handleUpload}
         disabled={uploadSpec.isPending}
-        className="px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm rounded-lg transition-colors disabled:opacity-50"
+        className="bg-primary hover:bg-primary-dark rounded-lg px-4 py-2 text-sm text-white transition-colors disabled:opacity-50"
       >
         {uploadSpec.isPending ? "Uploading..." : "Upload Spec"}
       </button>

--- a/src/components/test/ExecutionProgress.tsx
+++ b/src/components/test/ExecutionProgress.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { isTauriRuntime } from "../../lib/api";
 import type { TestProgress } from "../../lib/types";
 
 export function ExecutionProgress() {
   const [progress, setProgress] = useState<TestProgress | null>(null);
 
   useEffect(() => {
+    if (!isTauriRuntime()) return;
+
     const unlisten = listen<TestProgress>("test-progress", (event) => {
       setProgress(event.payload);
     });
@@ -20,16 +23,18 @@ export function ExecutionProgress() {
   const percent = progress.total > 0 ? (progress.completed / progress.total) * 100 : 0;
 
   return (
-    <div className={`rounded-lg border p-4 mb-4 ${isError ? "border-danger/30 bg-danger/5" : "border-border bg-surface-alt"}`}>
-      <div className="flex items-center justify-between mb-2">
+    <div
+      className={`mb-4 rounded-lg border p-4 ${isError ? "border-danger/30 bg-danger/5" : "border-border bg-surface-alt"}`}
+    >
+      <div className="mb-2 flex items-center justify-between">
         <span className={`text-sm ${isError ? "text-danger" : "text-text"}`}>
           {isError
             ? `Test execution error at ${progress.completed}/${progress.total}`
             : `Running tests... (${progress.completed}/${progress.total})`}
         </span>
-        <span className="text-xs text-text-muted">{percent.toFixed(0)}%</span>
+        <span className="text-text-muted text-xs">{percent.toFixed(0)}%</span>
       </div>
-      <div className="w-full bg-surface rounded-full h-2">
+      <div className="bg-surface h-2 w-full rounded-full">
         <div
           className={`h-2 rounded-full transition-all duration-300 ${isError ? "bg-danger" : "bg-primary"}`}
           style={{ width: `${percent}%` }}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 import type {
   Project,
   CreateProjectRequest,
@@ -14,40 +14,376 @@ import type {
   AppSettings,
 } from "./types";
 
+type InvokeArgs = Record<string, unknown>;
+
+interface MockState {
+  projects: Project[];
+  specs: Spec[];
+  requirements: Requirement[];
+  generatedTests: GeneratedTest[];
+  testResults: TestResult[];
+  reports: AlignmentReportWithMismatches[];
+  settings: AppSettings;
+}
+
+const mockState: MockState = {
+  projects: [],
+  specs: [],
+  requirements: [],
+  generatedTests: [],
+  testResults: [],
+  reports: [],
+  settings: {
+    api_key: "",
+    default_framework: "jest",
+    default_mode: "template",
+    scan_exclusions: ["node_modules", "dist", ".git"],
+  },
+};
+
+let mockId = 0;
+
+export const isTauriRuntime = () =>
+  typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+function now() {
+  return new Date().toISOString();
+}
+
+function nextId(prefix: string) {
+  mockId += 1;
+  return `mock-${prefix}-${mockId}`;
+}
+
+function withStats(project: Project): ProjectWithStats {
+  const specs = mockState.specs.filter((spec) => spec.project_id === project.id);
+  const reports = mockState.reports.filter((report) => report.project_id === project.id);
+  const latestReport = reports[reports.length - 1];
+  const latestResult = mockState.testResults[mockState.testResults.length - 1];
+
+  return {
+    ...project,
+    spec_count: specs.length,
+    coverage_percent: latestReport?.coverage_percent ?? null,
+    last_run_at: latestResult?.executed_at ?? null,
+  };
+}
+
+function parseRequirements(specId: string, content: string): Requirement[] {
+  const requirements: Requirement[] = [];
+  let section = "General";
+  let inRequirementSection = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    const heading = line.match(/^#{1,3}\s+(.+)$/);
+    if (heading) {
+      section = heading[1].trim();
+      const lower = section.toLowerCase();
+      inRequirementSection =
+        lower.includes("requirement") ||
+        lower.includes("user stor") ||
+        lower.includes("feature") ||
+        lower.includes("functional") ||
+        lower.includes("specification") ||
+        lower.includes("capability") ||
+        lower.includes("constraint") ||
+        lower.includes("acceptance criteria") ||
+        lower.includes("use case");
+      continue;
+    }
+
+    const item = line.match(/^\s*[-*]\s+(.+)$/);
+    if (!item) continue;
+
+    const description = item[1].trim();
+    const lower = description.toLowerCase();
+    const looksLikeRequirement =
+      lower.startsWith("as a ") ||
+      lower.startsWith("the system shall ") ||
+      lower.startsWith("the system must ") ||
+      lower.startsWith("the application shall ") ||
+      lower.startsWith("the application must ") ||
+      lower.startsWith("shall ") ||
+      lower.startsWith("must ") ||
+      lower.includes("**shall**") ||
+      lower.includes("**must**");
+
+    if (!inRequirementSection && !looksLikeRequirement) continue;
+
+    const lowerSection = section.toLowerCase();
+    const reqType =
+      lowerSection.includes("non-functional") ||
+      lowerSection.includes("performance") ||
+      lowerSection.includes("security") ||
+      lower.includes("performance") ||
+      lower.includes("latency") ||
+      lower.includes("availability")
+        ? "non_functional"
+        : lowerSection.includes("constraint") ||
+            lower.includes("constraint") ||
+            lower.includes("limitation")
+          ? "constraint"
+          : "functional";
+    const priority =
+      lower.includes("critical") || lower.includes("must have") || lower.includes("**must**")
+        ? "high"
+        : lower.includes("nice to have") || lower.includes("optional") || lower.includes("could")
+          ? "low"
+          : "medium";
+
+    requirements.push({
+      id: nextId("req"),
+      spec_id: specId,
+      section,
+      description,
+      req_type: reqType,
+      priority,
+    });
+  }
+
+  return requirements;
+}
+
+function generateMockTest(requirement: Requirement, req: GenerateTestsRequest): GeneratedTest {
+  const testName = requirement.description
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .slice(0, 8)
+    .join("_");
+  const code =
+    req.framework === "pytest"
+      ? `def test_${testName || "requirement"}():\n    \"\"\"${requirement.description}\"\"\"\n    assert True\n`
+      : `describe("${requirement.section}", () => {\n  it("${requirement.description}", () => {\n    expect(true).toBe(true);\n  });\n});\n`;
+
+  return {
+    id: nextId("test"),
+    requirement_id: requirement.id,
+    framework: req.framework,
+    code,
+    generation_mode: req.mode,
+    file_path: null,
+    created_at: now(),
+  };
+}
+
+async function mockInvoke<T>(command: string, args: InvokeArgs = {}): Promise<T> {
+  switch (command) {
+    case "create_project": {
+      const request = args.request as CreateProjectRequest;
+      const createdAt = now();
+      const project: Project = {
+        id: nextId("project"),
+        name: request.name,
+        codebase_path: request.codebase_path,
+        created_at: createdAt,
+        updated_at: createdAt,
+      };
+      mockState.projects.push(project);
+      return project as T;
+    }
+    case "list_projects":
+      return mockState.projects.map(withStats) as T;
+    case "get_project": {
+      const project = mockState.projects.find((item) => item.id === args.id);
+      if (!project) throw new Error("Project not found");
+      return withStats(project) as T;
+    }
+    case "delete_project": {
+      const id = args.id as string;
+      mockState.projects = mockState.projects.filter((item) => item.id !== id);
+      mockState.specs = mockState.specs.filter((item) => item.project_id !== id);
+      mockState.reports = mockState.reports.filter((item) => item.project_id !== id);
+      return undefined as T;
+    }
+    case "validate_path":
+      return Boolean(args.path) as T;
+    case "upload_spec": {
+      const spec: Spec = {
+        id: nextId("spec"),
+        project_id: args.project_id as string,
+        filename: args.filename as string,
+        content: args.content as string,
+        parsed_at: now(),
+        created_at: now(),
+      };
+      const requirements = parseRequirements(spec.id, spec.content);
+      mockState.specs.push(spec);
+      mockState.requirements.push(...requirements);
+      return { spec, requirements } as T;
+    }
+    case "get_spec": {
+      const spec = mockState.specs.find((item) => item.id === args.id);
+      if (!spec) throw new Error("Spec not found");
+      return {
+        spec,
+        requirements: mockState.requirements.filter((item) => item.spec_id === spec.id),
+      } as T;
+    }
+    case "list_specs":
+      return mockState.specs.filter((item) => item.project_id === args.project_id) as T;
+    case "delete_spec": {
+      const id = args.id as string;
+      mockState.specs = mockState.specs.filter((item) => item.id !== id);
+      mockState.requirements = mockState.requirements.filter((item) => item.spec_id !== id);
+      return undefined as T;
+    }
+    case "reparse_spec": {
+      const spec = mockState.specs.find((item) => item.id === args.id);
+      if (!spec) throw new Error("Spec not found");
+      mockState.requirements = mockState.requirements.filter((item) => item.spec_id !== spec.id);
+      const requirements = parseRequirements(spec.id, spec.content);
+      mockState.requirements.push(...requirements);
+      spec.parsed_at = now();
+      return requirements as T;
+    }
+    case "read_file_content":
+      throw new Error("Use the browser file picker in web preview");
+    case "generate_tests": {
+      const request = args.request as GenerateTestsRequest;
+      const tests = request.requirement_ids
+        .map((id) => mockState.requirements.find((requirement) => requirement.id === id))
+        .filter((requirement): requirement is Requirement => Boolean(requirement))
+        .map((requirement) => generateMockTest(requirement, request));
+      mockState.generatedTests.push(...tests);
+      return tests as T;
+    }
+    case "get_generated_tests":
+      return mockState.generatedTests.filter(
+        (item) => item.requirement_id === args.requirement_id,
+      ) as T;
+    case "get_all_generated_tests": {
+      const projectSpecIds = new Set(
+        mockState.specs
+          .filter((spec) => spec.project_id === args.project_id)
+          .map((spec) => spec.id),
+      );
+      const requirementIds = new Set(
+        mockState.requirements
+          .filter((requirement) => projectSpecIds.has(requirement.spec_id))
+          .map((requirement) => requirement.id),
+      );
+      return mockState.generatedTests.filter((test) =>
+        requirementIds.has(test.requirement_id),
+      ) as T;
+    }
+    case "save_test_to_disk":
+      return (args.path ?? "") as T;
+    case "save_settings":
+      mockState.settings = args.settings as AppSettings;
+      return undefined as T;
+    case "load_settings":
+      return mockState.settings as T;
+    case "execute_tests": {
+      const testIds = args.test_ids as string[];
+      const results = testIds.map<TestResult>((testId) => ({
+        id: nextId("result"),
+        generated_test_id: testId,
+        status: "passed",
+        execution_time_ms: 12,
+        stdout: "Mock browser preview execution passed",
+        stderr: "",
+        executed_at: now(),
+      }));
+      mockState.testResults.push(...results);
+      return results as T;
+    }
+    case "get_test_results":
+      return mockState.testResults as T;
+    case "get_test_result": {
+      const result = mockState.testResults.find((item) => item.id === args.id);
+      if (!result) throw new Error("Test result not found");
+      return result as T;
+    }
+    case "generate_alignment_report": {
+      const projectId = args.project_id as string;
+      const specs = mockState.specs.filter((spec) => spec.project_id === projectId);
+      const requirements = mockState.requirements.filter((requirement) =>
+        specs.some((spec) => spec.id === requirement.spec_id),
+      );
+      const covered = requirements.filter((requirement) =>
+        mockState.generatedTests.some((test) => test.requirement_id === requirement.id),
+      ).length;
+      const report: AlignmentReportWithMismatches = {
+        id: nextId("report"),
+        project_id: projectId,
+        coverage_percent: requirements.length ? (covered / requirements.length) * 100 : 0,
+        total_requirements: requirements.length,
+        covered_requirements: covered,
+        generated_at: now(),
+        mismatches: requirements
+          .filter(
+            (requirement) =>
+              !mockState.generatedTests.some((test) => test.requirement_id === requirement.id),
+          )
+          .map((requirement) => ({
+            id: nextId("mismatch"),
+            report_id: "browser-preview",
+            requirement_id: requirement.id,
+            spec_section: requirement.section,
+            code_element: null,
+            mismatch_type: "no_test_generated",
+            details: "No generated test covers this requirement in the browser preview.",
+          })),
+      };
+      report.mismatches = report.mismatches.map((mismatch) => ({
+        ...mismatch,
+        report_id: report.id,
+      }));
+      mockState.reports.push(report);
+      return report as T;
+    }
+    case "get_alignment_report": {
+      const report = mockState.reports.find((item) => item.id === args.id);
+      if (!report) throw new Error("Report not found");
+      return report as T;
+    }
+    case "list_reports":
+      return mockState.reports
+        .filter((item) => item.project_id === args.project_id)
+        .map(({ mismatches: _mismatches, ...report }) => report) as T;
+    case "export_report":
+      return JSON.stringify(
+        mockState.reports.find((item) => item.id === args.report_id) ?? null,
+        null,
+        2,
+      ) as T;
+    default:
+      throw new Error(`Unsupported browser preview command: ${command}`);
+  }
+}
+
+function invoke<T>(command: string, args?: InvokeArgs): Promise<T> {
+  return isTauriRuntime() ? tauriInvoke<T>(command, args) : mockInvoke<T>(command, args);
+}
+
 // Project commands
 export const createProject = (req: CreateProjectRequest) =>
   invoke<Project>("create_project", { request: req });
 
-export const listProjects = () =>
-  invoke<ProjectWithStats[]>("list_projects");
+export const listProjects = () => invoke<ProjectWithStats[]>("list_projects");
 
-export const getProject = (id: string) =>
-  invoke<ProjectWithStats>("get_project", { id });
+export const getProject = (id: string) => invoke<ProjectWithStats>("get_project", { id });
 
-export const deleteProject = (id: string) =>
-  invoke<void>("delete_project", { id });
+export const deleteProject = (id: string) => invoke<void>("delete_project", { id });
 
-export const validatePath = (path: string) =>
-  invoke<boolean>("validate_path", { path });
+export const validatePath = (path: string) => invoke<boolean>("validate_path", { path });
 
 // Spec commands
 export const uploadSpec = (projectId: string, filename: string, content: string) =>
   invoke<ParsedSpec>("upload_spec", { project_id: projectId, filename, content });
 
-export const getSpec = (id: string) =>
-  invoke<ParsedSpec>("get_spec", { id });
+export const getSpec = (id: string) => invoke<ParsedSpec>("get_spec", { id });
 
 export const listSpecs = (projectId: string) =>
   invoke<Spec[]>("list_specs", { project_id: projectId });
 
-export const deleteSpec = (id: string) =>
-  invoke<void>("delete_spec", { id });
+export const deleteSpec = (id: string) => invoke<void>("delete_spec", { id });
 
-export const reparseSpec = (id: string) =>
-  invoke<Requirement[]>("reparse_spec", { id });
+export const reparseSpec = (id: string) => invoke<Requirement[]>("reparse_spec", { id });
 
-export const readFileContent = (path: string) =>
-  invoke<string>("read_file_content", { path });
+export const readFileContent = (path: string) => invoke<string>("read_file_content", { path });
 
 // Test generation commands
 export const generateTests = (req: GenerateTestsRequest) =>
@@ -63,11 +399,9 @@ export const saveTestToDisk = (testId: string, path: string) =>
   invoke<string>("save_test_to_disk", { test_id: testId, path });
 
 // Settings commands
-export const saveSettings = (settings: AppSettings) =>
-  invoke<void>("save_settings", { settings });
+export const saveSettings = (settings: AppSettings) => invoke<void>("save_settings", { settings });
 
-export const loadSettings = () =>
-  invoke<AppSettings>("load_settings");
+export const loadSettings = () => invoke<AppSettings>("load_settings");
 
 // Test execution commands
 export const executeTests = (projectId: string, testIds: string[]) =>
@@ -76,8 +410,7 @@ export const executeTests = (projectId: string, testIds: string[]) =>
 export const getTestResults = (projectId: string) =>
   invoke<TestResult[]>("get_test_results", { project_id: projectId });
 
-export const getTestResult = (id: string) =>
-  invoke<TestResult>("get_test_result", { id });
+export const getTestResult = (id: string) => invoke<TestResult>("get_test_result", { id });
 
 // Report commands
 export const generateAlignmentReport = (projectId: string) =>


### PR DESCRIPTION
## What
- Align the Tauri runtime lockfile stack so the desktop workflow smoke compiles again.
- Add browser-preview support for representative SpecCompanion QA flows, including safe mock Tauri command handling and web upload controls.
- Refresh the Codex communication contract in repo instructions.

## Why
- Closes #1.
- The GitHub/Notion activation packet needed a verified baseline UI/Tauri path before leaving the review lane.

## How
- Keeps native Tauri paths intact while adding guarded browser-preview behavior for QA.
- Stabilizes report chart dimensions and native-only dialog/event calls for browser tests.
- Removes a stale unused Rust test import and aligns locked Tauri runtime dependencies.

## Testing
- `pnpm ui:gate:static` passed.
- `pnpm workflow:smoke` passed.
- `pnpm ui:gate:regression` passed: 4 visual + 4 a11y tests.
- `pnpm ui:test:lighthouse` passed; report: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1780223052094-8672.report.html
- `cargo test --manifest-path src-tauri/Cargo.toml` passed earlier on this branch.
- `pnpm git:guard:all` passed earlier on this branch.

## Performance impact
- Lighthouse passed locally via LHCI.
- No API, DB, or runtime data-path impact expected from the browser-preview guards.

## Risk / Notes
- Browser-preview behavior uses mock command responses and should not be confused with native Tauri integration coverage.
- GitHub token was not set for LHCI, so the Lighthouse report uploaded but no GitHub status was written by LHCI.

## Screenshots (UI only)
- Not captured in this pass.

## Lockfile rationale (if lockfile changed)
- Required to align the locked Tauri runtime family after a mismatched `tauri-runtime` / `tauri-runtime-wry` stack caused compile failures.

## Baseline governance (if .perf-baselines changed)
- N/A