### PR TITLE
fix: unblock Dependabot policy gates

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -7,5 +7,49 @@ on:
   workflow_dispatch:
 
 jobs:
-  git-hygiene:
-    uses: saagpatel/sovereign/.github/workflows/git-hygiene.yml@fdd225434bc1185911e53f8df1834ac058949580
+  commitlint:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed
+
+  pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  branch-name:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const branch = context.payload.pull_request?.head?.ref || "";
+            const pattern = /^codex\/(feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix)\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+            const automationPattern = /^dependabot\/.+$/;
+            if (!pattern.test(branch) && !automationPattern.test(branch)) {
+              core.setFailed(`Invalid branch name: ${branch}`);
+            }
+
+  secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -7,4 +7,5 @@ on:
 
 jobs:
   enforce:
+    if: github.actor != 'dependabot[bot]'
     uses: saagpatel/sovereign/.github/workflows/lockfile-rationale.yml@fdd225434bc1185911e53f8df1834ac058949580

--- a/scripts/git/guard-branch.sh
+++ b/scripts/git/guard-branch.sh
@@ -2,12 +2,20 @@
 set -euo pipefail
 
 # codex-os-managed
-branch="$(git rev-parse --abbrev-ref HEAD)"
+branch="${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD)}"
+
+if [[ "$branch" == "HEAD" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  branch="$GITHUB_REF_NAME"
+fi
 pattern='^codex/(feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix)/[a-z0-9]+(-[a-z0-9]+)*$'
 
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "Direct work on $branch is blocked."
   exit 1
+fi
+
+if [[ "$branch" == dependabot/* ]]; then
+  exit 0
 fi
 
 if ! [[ "$branch" =~ $pattern ]]; then


### PR DESCRIPTION
## Summary
- make git hygiene local so dependabot/* branches are accepted
- keep commitlint for human-authored PRs
- skip lockfile rationale enforcement for Dependabot PRs
- allow dependabot/* through the local branch guard

## Verification
- GITHUB_HEAD_REF=dependabot/cargo/example bash scripts/git/guard-branch.sh
- GITHUB_HEAD_REF=codex/fix/example bash scripts/git/guard-branch.sh
- verified main and feature/foo still fail the guard